### PR TITLE
Capture default environment colors and userdata

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,7 @@
     <div class="info-box">
         <p>Id Lokacji: <span class="room-id"></span></p>
         <p>Nazwa: <span class="room-name"></span></p>
+        <p>Env Id: <span class="room-env"></span></p>
         <p>Koordynaty:
         <ul>
             <li>x: <span class="coord-x"></span></li>
@@ -188,6 +189,10 @@
         </div>
         <div class="special">
             <p>Specjalne:</p>
+            <ul></ul>
+        </div>
+        <div class="userData">
+            <p>Inne:</p>
             <ul></ul>
         </div>
     </div>

--- a/js/map.js
+++ b/js/map.js
@@ -59,7 +59,7 @@ class MapRenderer {
         this.isDrag = false;
 
         this.rasterLayer = new Layer();
-        this.rasterLayer.name = "Raster"
+        this.rasterLayer.name = "Raster";
     }
 
     render(highlights) {

--- a/js/map.js
+++ b/js/map.js
@@ -580,12 +580,26 @@ class MapRenderer {
         infoBox.toggle(true);
         infoBox.find(".room-id").html(room.id);
         infoBox.find(".room-name").html(room.name);
+        infoBox.find(".room-env").html(room.env);
         infoBox.find(".coord-x").html(room.x);
         infoBox.find(".coord-y").html(room.y);
         infoBox.find(".coord-z").html(room.z);
 
         this.infoExitsGroup(infoBox.find(".exits"), room.exits);
         this.infoExitsGroup(infoBox.find(".special"), room.specialExits);
+
+        this.userDataGroup(infoBox.find(".userData"), room.userData);
+    }
+
+    userDataGroup(container, userData) {
+        let containerList = container.find("ul");
+        containerList.html("");
+        let show = false;
+        for (let userDataKey in userData) {
+            show = true;
+            containerList.append("<li>" + userDataKey + ":<br>&nbsp; &nbsp; &nbsp;" + userData[userDataKey] + "</lu>");
+        }
+        container.toggle(show);
     }
 
     infoExitsGroup(container, exits) {

--- a/js/map.js
+++ b/js/map.js
@@ -597,7 +597,7 @@ class MapRenderer {
         let show = false;
         for (let userDataKey in userData) {
             show = true;
-            containerList.append("<li>" + userDataKey + ":<br>&nbsp; &nbsp; &nbsp;" + userData[userDataKey] + "</lu>");
+            containerList.append("<li>" + userDataKey + ":<br>&nbsp; &nbsp; &nbsp;" + userData[userDataKey] + "</li>");
         }
         container.toggle(show);
     }


### PR DESCRIPTION
This PR captures the default environment colors for environments 1-255, then captures custom environment colors, overwriting the defaults where there is overlap.

Also exports room userdata as key:value pairs and displays this information in the infobox if it is set.

Screenshot is the english version but I've tried to use Polish for all the displayed bits in this PR.

![image](https://user-images.githubusercontent.com/3660/85236266-7a12e800-b3ea-11ea-83bf-b9dbebe28ab8.png)
