### PR TITLE
Combined areas view (proof of concept)

### DIFF
--- a/map-exporter.lua
+++ b/map-exporter.lua
@@ -34,6 +34,7 @@ function MapExporter:exportRooms()
 				areaName = "Combined Area View",
 				rooms = {},
 				labels = {},
+				combinedAreaIDs = {},
 		}
     for areaName, areaId in pairs(getAreaTable()) do
 
@@ -47,6 +48,14 @@ function MapExporter:exportRooms()
             rooms = {},
             labels = {}
         }
+				if MapExporterCombinedAreaView and
+					 MapExporterCombinedAreaView[areaRooms.areaName] then
+					  areaRooms.combinedAreaView = true
+						areaRooms.xShift = MapExporterCombinedAreaView[areaRooms.areaName].xShift
+						areaRooms.yShift = MapExporterCombinedAreaView[areaRooms.areaName].yShift
+						areaRooms.zShift = MapExporterCombinedAreaView[areaRooms.areaName].zShift
+						table.insert(combinedAreaViewRooms.combinedAreaIDs,areaId)
+				end
 				
         labels = {}
         if type(labelIds) == "table" then

--- a/map-exporter.lua
+++ b/map-exporter.lua
@@ -56,7 +56,13 @@ function MapExporter:exportRooms()
                 table.insert(labels, label)
 								if MapExporterCombinedAreaView and
 									 MapExporterCombinedAreaView[areaRooms.areaName] then
-										table.insert(combinedAreaViewRooms.labels,label)
+									  local combinedAreaViewLabel = getMapLabel(areaId, k)
+										combinedAreaViewLabel.id = combinedAreaViewRooms.areaId
+										local shift = function(a,b) if a and type(a) == "number" and b and type(b) == "number" then return a+b else return a end end
+										combinedAreaViewLabel.X = shift(combinedAreaViewLabel.X,MapExporterCombinedAreaView[areaRooms.areaName].xShift)
+										combinedAreaViewLabel.Y = shift(combinedAreaViewLabel.Y,MapExporterCombinedAreaView[areaRooms.areaName].yShift)
+										combinedAreaViewLabel.Z = shift(combinedAreaViewLabel.Z,MapExporterCombinedAreaView[areaRooms.areaName].zShift)										 
+										table.insert(combinedAreaViewRooms.labels,combinedAreaViewLabel)
 								end
             end
         end


### PR DESCRIPTION
MapExporterCombinedAreaView is a global variable table that contains a list of area names that should be duplicated and displayed into a new master "Combined Area View" with xShift,yShift, and zShift properties passed into the table.

E.G. To add the "main" and "secondary" area names to the "Combined Area View" area, and shift the "secondary" area -100 X and -50 Y on the display, you'd specify the following global variables:
MapExporterCombinedAreaView = {}
MapExporterCombinedAreaView["main"]={xShift=0, yShift=0, zShift=0}
MapExporterCombinedAreaView["secondary"]={xShift=-100, yShift=-50, zShift=0}

This commit is just a first pass, and isn't very efficient as it effectively duplicates any rooms to add them to a new area called "Combined Area View", but the user must specify any areas they want in this view with the MapExporterCombinedAreaView table; if not specified nothing is duplicated, and it should handle invalid values okay, so I think this is fairly safe as an interim solution.

The same concept should be able to be used to adjust just the display of rooms, so that no data is duplicated, as a list of xShift, yShift, and zShift values is already passed into each areaRooms table that has a an entry in MapExporterCombinedAreaView, but the javascript hasn't been updated to take advantage of that data, yet.